### PR TITLE
Add pytest suite for core calculations and pipeline persistence

### DIFF
--- a/docs/issues/add-testing-suite.md
+++ b/docs/issues/add-testing-suite.md
@@ -1,0 +1,19 @@
+# Issue Draft: Add a Comprehensive Testing Suite
+
+## Summary
+The project has pytest and tooling configured but lacks a committed test suite covering core business logic and pipeline persistence.
+
+## Proposed Work
+- Add unit tests for:
+  - calculation helpers (`cagr`, `eps_cagr_from_annual`)
+  - validation helpers (`validate_positive`, `cap_outliers`)
+  - PEGY calculator behavior and failure flags
+- Add an integration-style test for the daily snapshot pipeline against in-memory SQLite.
+
+## Acceptance Criteria
+- `pytest` runs successfully in CI/local and validates core logic paths.
+- Tests cover both happy paths and input-validation edge cases.
+- Pipeline test confirms snapshots are persisted.
+
+## Notes
+This file is an issue draft because this local environment is not connected to a GitHub remote with issue-creation credentials.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,27 @@
+import pytest
+
+from pegy_tracker.calculations.metrics import cagr, eps_cagr_from_annual
+
+
+def test_cagr_returns_expected_value() -> None:
+    result = cagr(100.0, 121.0, 2)
+    assert result is not None
+    assert result == pytest.approx(0.1)
+
+
+def test_cagr_invalid_inputs_return_none() -> None:
+    assert cagr(100.0, 121.0, 0) is None
+    assert cagr(-1.0, 121.0, 2) is None
+    assert cagr(100.0, 0.0, 2) is None
+
+
+def test_eps_cagr_from_annual_happy_path() -> None:
+    eps = {2019: 1.0, 2024: 2.0}
+    result = eps_cagr_from_annual(eps, years=5)
+    assert result is not None
+    assert round(result, 6) == round((2.0 ** (1 / 5)) - 1, 6)
+
+
+def test_eps_cagr_from_annual_requires_start_year() -> None:
+    eps = {2020: 1.0, 2024: 2.0}
+    assert eps_cagr_from_annual(eps, years=5) is None

--- a/tests/test_pegy_calculator.py
+++ b/tests/test_pegy_calculator.py
@@ -1,0 +1,56 @@
+from datetime import date
+
+from pegy_tracker.calculations.pegy import PegyCalculator
+from pegy_tracker.domain.models import (
+    DividendInfo,
+    EarningsInfo,
+    FundamentalsSnapshot,
+    InstrumentId,
+    PricePoint,
+)
+
+
+def make_snapshot(*, pe_ttm: float | None, eps_ttm: float | None, growth_start: float, growth_end: float, div_yield: float | None) -> FundamentalsSnapshot:
+    asof = date(2024, 1, 1)
+    return FundamentalsSnapshot(
+        instrument=InstrumentId(symbol="EQNR.OL", mic="XOSL"),
+        asof=asof,
+        price=PricePoint(asof=asof, close=100.0, currency="NOK"),
+        earnings=EarningsInfo(
+            asof=asof,
+            eps_ttm=eps_ttm,
+            pe_ttm=pe_ttm,
+            eps_annual={2019: growth_start, 2024: growth_end},
+        ),
+        dividends=DividendInfo(asof=asof, ttm_dividend_per_share=1.0, dividend_yield=div_yield),
+    )
+
+
+def test_compute_returns_metrics_when_inputs_are_valid() -> None:
+    calc = PegyCalculator()
+    snap = make_snapshot(pe_ttm=15.0, eps_ttm=10.0, growth_start=1.0, growth_end=2.0, div_yield=0.05)
+
+    result = calc.compute(snap)
+
+    assert result.flags == []
+    assert result.metrics["pe"] == 15.0
+    assert "pegy" in result.metrics
+
+
+def test_compute_derives_pe_from_price_and_eps_ttm() -> None:
+    calc = PegyCalculator()
+    snap = make_snapshot(pe_ttm=None, eps_ttm=5.0, growth_start=1.0, growth_end=2.0, div_yield=0.05)
+
+    result = calc.compute(snap)
+
+    assert result.metrics["pe"] == 20.0
+
+
+def test_compute_returns_flags_for_missing_fields() -> None:
+    calc = PegyCalculator()
+    snap = make_snapshot(pe_ttm=10.0, eps_ttm=5.0, growth_start=1.0, growth_end=2.0, div_yield=None)
+
+    result = calc.compute(snap)
+
+    assert result.metrics == {}
+    assert "missing:div_yield" in result.flags

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,60 @@
+import sqlite3
+from datetime import date
+
+from pegy_tracker.calculations.pegy import PegyCalculator
+from pegy_tracker.domain.models import (
+    DividendInfo,
+    EarningsInfo,
+    FundamentalsSnapshot,
+    InstrumentId,
+    PricePoint,
+)
+from pegy_tracker.markets.base import SimpleMarket
+from pegy_tracker.orchestration.pipeline import DailySnapshotPipeline
+from pegy_tracker.providers.base import MarketDataProvider, MarketUniverse
+
+
+class StubMarket(SimpleMarket):
+    def __init__(self) -> None:
+        super().__init__(mic="XOSL")
+
+    def normalize_symbol(self, raw: str) -> str:
+        return raw
+
+    def default_symbols(self) -> list[str]:
+        return ["EQNR.OL"]
+
+
+class StubProvider(MarketDataProvider):
+    name = "stub"
+
+    def list_equities(self, market: MarketUniverse):
+        return []
+
+    def get_fundamentals_snapshot(self, instrument: InstrumentId, asof: date | None = None) -> FundamentalsSnapshot:
+        snapshot_date = asof or date.today()
+        return FundamentalsSnapshot(
+            instrument=instrument,
+            asof=snapshot_date,
+            price=PricePoint(asof=snapshot_date, close=100.0, currency="NOK"),
+            earnings=EarningsInfo(asof=snapshot_date, eps_ttm=5.0, pe_ttm=10.0, eps_annual={2019: 1.0, 2024: 2.0}),
+            dividends=DividendInfo(asof=snapshot_date, ttm_dividend_per_share=2.0, dividend_yield=0.05),
+        )
+
+
+def test_pipeline_persists_instrument_and_snapshot() -> None:
+    con = sqlite3.connect(":memory:")
+    with open("src/pegy_tracker/storage/schema.sql", encoding="utf-8") as f:
+        con.executescript(f.read())
+
+    pipeline = DailySnapshotPipeline(
+        provider=StubProvider(),
+        market=StubMarket(),
+        calculator=PegyCalculator(),
+        con=con,
+    )
+
+    pipeline.run(symbols=["EQNR.OL"], asof=date(2024, 1, 1))
+
+    snapshot_count = con.execute("SELECT COUNT(*) FROM snapshots").fetchone()[0]
+    assert snapshot_count == 1

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,29 @@
+from pegy_tracker.calculations.validation import cap_outliers, validate_positive
+
+
+def test_validate_positive_updates_flags() -> None:
+    flags: list[str] = []
+    assert validate_positive(None, "pe", flags) is False
+    assert flags == ["missing:pe"]
+
+    flags.clear()
+    assert validate_positive(0.0, "pe", flags) is False
+    assert flags == ["nonpositive:pe"]
+
+    flags.clear()
+    assert validate_positive(3.2, "pe", flags) is True
+    assert flags == []
+
+
+def test_cap_outliers_clips_and_flags() -> None:
+    flags: list[str] = []
+    assert cap_outliers(-1.0, 0.0, 1.0, "growth", flags) == 0.0
+    assert flags == ["clipped_low:growth"]
+
+    flags.clear()
+    assert cap_outliers(2.0, 0.0, 1.0, "growth", flags) == 1.0
+    assert flags == ["clipped_high:growth"]
+
+    flags.clear()
+    assert cap_outliers(0.5, 0.0, 1.0, "growth", flags) == 0.5
+    assert flags == []


### PR DESCRIPTION
### Motivation
- The repository had testing tooling configured but no committed tests, leaving core calculation logic and the snapshot pipeline unverified.
- A minimal, focused test suite reduces regression risk for PEG/PEGY calculations and storage persistence behavior.

### Description
- Add unit tests for metric helpers in `tests/test_metrics.py` that cover `cagr` and `eps_cagr_from_annual` happy and edge cases.
- Add validation helper tests in `tests/test_validation.py` for `validate_positive` and `cap_outliers` including flag behavior.
- Add `PegyCalculator` unit tests in `tests/test_pegy_calculator.py` covering normal metrics, derived P/E, and missing-field flags.
- Add an integration-style test in `tests/test_pipeline.py` using an in-memory SQLite DB and a stub provider/market to verify that `DailySnapshotPipeline` persists snapshots, and include an issue draft at `docs/issues/add-testing-suite.md` for creating a GitHub issue describing this work.

### Testing
- Ran `pytest` which completed successfully with `10 passed` tests.
- Ran `ruff check` on the new tests and applied `--fix` to resolve minor import-order/format issues.
- The pipeline test uses an in-memory SQLite DB and verifies persistence by asserting a single row in the `snapshots` table.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d81e1761883299538123eff924713)